### PR TITLE
[Fix] Formatting, removing bold format

### DIFF
--- a/modules/developers-guide/pages/tutorials/hello-location.adoc
+++ b/modules/developers-guide/pages/tutorials/hello-location.adoc
@@ -259,7 +259,7 @@ In this context, therefore, the `+[Text]+` indicates an array of a collection of
 +
 The code sample also uses the basic format of an `+apply+` operation for the array, which can be abstracted as:
 +
-[source,bash,subs="quotes"]
+[source,bash]
 ----
 public func apply<A, B>(fs : [A -> B], xs : [A]) : [B] {
     var ys : [B] = [];


### PR DESCRIPTION
Looks like the `sub="quotes"` parameter on L262 caused the rest of the tutorial to be bold.
Removing this parameter to adjust the format.

current state
![](https://www.evernote.com/l/ACWtRI2GOI1FCr4dSyCxAl3g6AsW1j62vV0B/image.png)
